### PR TITLE
feat: add language selection

### DIFF
--- a/src/NerdMinerV2.ino.cpp
+++ b/src/NerdMinerV2.ino.cpp
@@ -13,7 +13,9 @@
 #include "monitor.h"
 #include "drivers/displays/display.h"
 #include "drivers/storage/SDCard.h"
+#include "drivers/storage/storage.h"
 #include "timeconst.h"
+#include "lang/lang.h"
 
 #ifdef TOUCH_ENABLE
 #include "TouchHandler.h"
@@ -37,6 +39,7 @@ extern TouchHandler touchHandler;
 #endif
 
 extern monitor_data mMonitor;
+extern TSettings Settings;
 
 #ifdef SD_ID
   SDCard SDCrd = SDCard(SD_ID);
@@ -118,6 +121,7 @@ void setup()
 
   /******** INIT WIFI ************/
   init_WifiManager();
+  setCurrentLang(Settings.Language);
 
   server.on("/", handleStatus);
   server.begin();

--- a/src/drivers/storage/SDCard.cpp
+++ b/src/drivers/storage/SDCard.cpp
@@ -133,6 +133,11 @@ bool SDCard::loadConfigFile(TSettings* Settings)
                     } else {
                         Settings->Brightness = 250;
                     }
+                    if (json.containsKey(JSON_KEY_LANGUAGE)) {
+                        Settings->Language = json[JSON_KEY_LANGUAGE].as<uint8_t>();
+                    } else {
+                        Settings->Language = DEFAULT_LANGUAGE;
+                    }
                     // Serial.printf("Carteira Lida SD:%s\n", Settings.BtcWallet);       
                     Serial.printf("Carteira Lida SDs:%s\n", Settings->BtcWallet);                       
                     return true;

--- a/src/drivers/storage/nvMemory.cpp
+++ b/src/drivers/storage/nvMemory.cpp
@@ -37,6 +37,7 @@ bool nvMemory::saveConfig(TSettings* Settings)
         json[JSON_SPIFFS_KEY_STATS2NV] = Settings->saveStats;
         json[JSON_SPIFFS_KEY_INVCOLOR] = Settings->invertColors;
         json[JSON_SPIFFS_KEY_BRIGHTNESS] = Settings->Brightness;
+        json[JSON_SPIFFS_KEY_LANGUAGE] = Settings->Language;
 
         // Open config file
         File configFile = SPIFFS.open(JSON_CONFIG_FILE, "w");
@@ -108,6 +109,11 @@ bool nvMemory::loadConfig(TSettings* Settings)
                         Settings->Brightness = json[JSON_SPIFFS_KEY_BRIGHTNESS].as<int>();
                     } else {
                         Settings->Brightness = 250;
+                    }
+                    if (json.containsKey(JSON_SPIFFS_KEY_LANGUAGE)) {
+                        Settings->Language = json[JSON_SPIFFS_KEY_LANGUAGE].as<uint8_t>();
+                    } else {
+                        Settings->Language = DEFAULT_LANGUAGE;
                     }
                     return true;
                 }

--- a/src/drivers/storage/storage.h
+++ b/src/drivers/storage/storage.h
@@ -7,58 +7,63 @@
 
 // default settings
 #ifndef HAN
-#define DEFAULT_SSID		"NerdMinerAP"
+#define DEFAULT_SSID            "NerdMinerAP"
 #else
-#define DEFAULT_SSID		"HanSoloAP"
+#define DEFAULT_SSID            "HanSoloAP"
 #endif
-#define DEFAULT_WIFIPW		"MineYourCoins"
-#define DEFAULT_POOLURL		"public-pool.io"
-#define DEFAULT_POOLPASS	"x"
-#define DEFAULT_WALLETID	"yourBtcAddress"
-#define DEFAULT_POOLPORT	21496
-#define DEFAULT_TIMEZONE	2
-#define DEFAULT_SAVESTATS	false
-#define DEFAULT_INVERTCOLORS	false
-#define DEFAULT_BRIGHTNESS	250
+#define DEFAULT_WIFIPW          "MineYourCoins"
+#define DEFAULT_POOLURL         "public-pool.io"
+#define DEFAULT_POOLPASS        "x"
+#define DEFAULT_WALLETID        "yourBtcAddress"
+#define DEFAULT_POOLPORT        21496
+#define DEFAULT_TIMEZONE        2
+#define DEFAULT_SAVESTATS       false
+#define DEFAULT_INVERTCOLORS    false
+#define DEFAULT_BRIGHTNESS      250
+#define DEFAULT_LANGUAGE        0
 
 // JSON config files
-#define JSON_CONFIG_FILE	"/config.json"
+#define JSON_CONFIG_FILE        "/config.json"
 
 // JSON config file SD card (for user interaction, readme.md)
-#define JSON_KEY_SSID		"SSID"
-#define JSON_KEY_PASW		"WifiPW"
-#define JSON_KEY_POOLURL	"PoolUrl"
-#define JSON_KEY_POOLPASS	"PoolPassword"
-#define JSON_KEY_WALLETID	"BtcWallet"
-#define JSON_KEY_POOLPORT	"PoolPort"
-#define JSON_KEY_TIMEZONE	"Timezone"
-#define JSON_KEY_STATS2NV	"SaveStats"
-#define JSON_KEY_INVCOLOR	"invertColors"
-#define JSON_KEY_BRIGHTNESS	"Brightness"
+#define JSON_KEY_SSID           "SSID"
+#define JSON_KEY_PASW           "WifiPW"
+#define JSON_KEY_POOLURL        "PoolUrl"
+#define JSON_KEY_POOLPASS       "PoolPassword"
+#define JSON_KEY_WALLETID       "BtcWallet"
+#define JSON_KEY_POOLPORT       "PoolPort"
+#define JSON_KEY_TIMEZONE       "Timezone"
+#define JSON_KEY_STATS2NV       "SaveStats"
+#define JSON_KEY_INVCOLOR       "invertColors"
+#define JSON_KEY_BRIGHTNESS     "Brightness"
+#define JSON_KEY_LANGUAGE       "Language"
 
 // JSON config file SPIFFS (different for backward compatibility with existing devices)
-#define JSON_SPIFFS_KEY_POOLURL		"poolString"
-#define JSON_SPIFFS_KEY_POOLPORT	"portNumber"
-#define JSON_SPIFFS_KEY_POOLPASS	"poolPassword"
-#define JSON_SPIFFS_KEY_WALLETID	"btcString"
-#define JSON_SPIFFS_KEY_TIMEZONE	"gmtZone"
-#define JSON_SPIFFS_KEY_STATS2NV	"saveStatsToNVS"
-#define JSON_SPIFFS_KEY_INVCOLOR	"invertColors"
-#define JSON_SPIFFS_KEY_BRIGHTNESS	"Brightness"
+#define JSON_SPIFFS_KEY_POOLURL         "poolString"
+#define JSON_SPIFFS_KEY_POOLPORT        "portNumber"
+#define JSON_SPIFFS_KEY_POOLPASS        "poolPassword"
+#define JSON_SPIFFS_KEY_WALLETID        "btcString"
+#define JSON_SPIFFS_KEY_TIMEZONE        "gmtZone"
+#define JSON_SPIFFS_KEY_STATS2NV        "saveStatsToNVS"
+#define JSON_SPIFFS_KEY_INVCOLOR        "invertColors"
+#define JSON_SPIFFS_KEY_BRIGHTNESS      "Brightness"
+#define JSON_SPIFFS_KEY_LANGUAGE         "Language"
 
 // settings
 struct TSettings
 {
-	String WifiSSID{ DEFAULT_SSID };
-	String WifiPW{ DEFAULT_WIFIPW };
-	String PoolAddress{ DEFAULT_POOLURL };
-	char BtcWallet[80]{ DEFAULT_WALLETID };
-	char PoolPassword[80]{ DEFAULT_POOLPASS };
-	int PoolPort{ DEFAULT_POOLPORT };
-	int Timezone{ DEFAULT_TIMEZONE };
-	bool saveStats{ DEFAULT_SAVESTATS };
-	bool invertColors{ DEFAULT_INVERTCOLORS };
-	int Brightness{ DEFAULT_BRIGHTNESS };
+        String WifiSSID{ DEFAULT_SSID };
+        String WifiPW{ DEFAULT_WIFIPW };
+        String PoolAddress{ DEFAULT_POOLURL };
+        char BtcWallet[80]{ DEFAULT_WALLETID };
+        char PoolPassword[80]{ DEFAULT_POOLPASS };
+        int PoolPort{ DEFAULT_POOLPORT };
+        int Timezone{ DEFAULT_TIMEZONE };
+        bool saveStats{ DEFAULT_SAVESTATS };
+        bool invertColors{ DEFAULT_INVERTCOLORS };
+        int Brightness{ DEFAULT_BRIGHTNESS };
+        uint8_t Language{ DEFAULT_LANGUAGE };
 };
 
 #endif // _STORAGE_H_
+

--- a/src/lang/lang.cpp
+++ b/src/lang/lang.cpp
@@ -4,3 +4,17 @@
 #include "lang_ja.h"
 
 const LanguagePack* CurrentLang = &LanguagePack_en;
+
+void setCurrentLang(uint8_t lang) {
+    switch (lang) {
+        case 1:
+            CurrentLang = &LanguagePack_zh_tw;
+            break;
+        case 2:
+            CurrentLang = &LanguagePack_ja;
+            break;
+        default:
+            CurrentLang = &LanguagePack_en;
+            break;
+    }
+}

--- a/src/lang/lang.h
+++ b/src/lang/lang.h
@@ -47,6 +47,7 @@ extern const LanguagePack LanguagePack_en;
 extern const LanguagePack LanguagePack_zh_tw;
 extern const LanguagePack LanguagePack_ja;
 extern const LanguagePack* CurrentLang;
+void setCurrentLang(uint8_t lang);
 
 #define LANG_TEXT_STATS (CurrentLang->text[LANG_TEXT_STATS])
 #define LANG_TEXT_BTC (CurrentLang->text[LANG_TEXT_BTC])

--- a/src/wManager.cpp
+++ b/src/wManager.cpp
@@ -112,8 +112,10 @@ void init_WifiManager()
         }
     };
     
-    // Free the memory from SDCard class 
+    // Free the memory from SDCard class
     SDCrd.terminate();
+
+    setCurrentLang(Settings.Language);
     
     // Reset settings (only for development)
     //wm.resetSettings();
@@ -138,6 +140,26 @@ void init_WifiManager()
     //wm.setConfigPortalTimeout(120); //seconds
 
     // Custom elements
+
+    char langSel0[10] = "";
+    char langSel1[10] = "";
+    char langSel2[10] = "";
+    switch (Settings.Language) {
+        case 1:
+            strcpy(langSel1, "selected");
+            break;
+        case 2:
+            strcpy(langSel2, "selected");
+            break;
+        default:
+            strcpy(langSel0, "selected");
+            break;
+    }
+    char languageDropdown[200];
+    snprintf(languageDropdown, sizeof(languageDropdown),
+             "<br/><label for='language'>Language</label><select name='language' id='language'><option value='0' %s>English</option><option value='1' %s>繁中</option><option value='2' %s>日本語</option></select>",
+             langSel0, langSel1, langSel2);
+    WiFiManagerParameter language_dropdown(languageDropdown);
 
     // Text box (String) - 80 characters maximum
     WiFiManagerParameter pool_text_box("Poolurl", "Pool url", Settings.PoolAddress.c_str(), 80);
@@ -172,6 +194,7 @@ void init_WifiManager()
   WiFiManagerParameter password_text_box("Poolpassword - Optional", "Pool password", Settings.PoolPassword, 80);
 
   // Add all defined parameters
+  wm.addParameter(&language_dropdown);
   wm.addParameter(&pool_text_box);
   wm.addParameter(&port_text_box_num);
   wm.addParameter(&password_text_box);
@@ -215,6 +238,9 @@ void init_WifiManager()
             Settings.Timezone = atoi(time_text_box_num.getValue());
             //Serial.println(save_stats_to_nvs.getValue());
             Settings.saveStats = (strncmp(save_stats_to_nvs.getValue(), "T", 1) == 0);
+            if (wm.server->hasArg("language")) {
+                Settings.Language = wm.server->arg("language").toInt();
+            }
             #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
                 Settings.invertColors = (strncmp(invertColors.getValue(), "T", 1) == 0);
             #endif
@@ -248,6 +274,9 @@ void init_WifiManager()
                 Settings.Timezone = atoi(time_text_box_num.getValue());
                 // Serial.println(save_stats_to_nvs.getValue());
                 Settings.saveStats = (strncmp(save_stats_to_nvs.getValue(), "T", 1) == 0);
+                if (wm.server->hasArg("language")) {
+                    Settings.Language = wm.server->arg("language").toInt();
+                }
                 #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
                 Settings.invertColors = (strncmp(invertColors.getValue(), "T", 1) == 0);
                 #endif
@@ -297,6 +326,9 @@ void init_WifiManager()
         Settings.Timezone = atoi(time_text_box_num.getValue());
         Serial.print(LANG_TEXT_TIMEZONE_FROMUTC);
         Serial.println(Settings.Timezone);
+        if (wm.server->hasArg("language")) {
+            Settings.Language = wm.server->arg("language").toInt();
+        }
 
         #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
         Settings.invertColors = (strncmp(invertColors.getValue(), "T", 1) == 0);
@@ -339,6 +371,9 @@ void init_WifiManager()
     Settings.Timezone = atoi(time_text_box_num.getValue());
     Serial.print(LANG_TEXT_TIMEZONE_FROMUTC);
     Serial.println(Settings.Timezone);
+    if (wm.server->hasArg("language")) {
+        Settings.Language = wm.server->arg("language").toInt();
+    }
 
     #ifdef ESP32_2432S028R
     Settings.invertColors = (strncmp(invertColors.getValue(), "T", 1) == 0);
@@ -350,8 +385,9 @@ void init_WifiManager()
     if (shouldSaveConfig)
     {
         nvMem.saveConfig(&Settings);
+        setCurrentLang(Settings.Language);
         #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
-         if (Settings.invertColors) ESP.restart();                
+         if (Settings.invertColors) ESP.restart();
         #endif
         #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
         if (Settings.Brightness != 250) ESP.restart();


### PR DESCRIPTION
## Summary
- add language field to persistent settings and JSON keys
- support language selection in WiFi manager portal
- initialize current language from saved settings at startup

## Testing
- `pio run -e M5Stick-C` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68b10ed509588321b214aad723c88531