### PR TITLE
預設語言改為繁體中文

### DIFF
--- a/src/drivers/storage/storage.h
+++ b/src/drivers/storage/storage.h
@@ -2,6 +2,7 @@
 #define _STORAGE_H_
 
 #include <Arduino.h>
+#include "../../lang/lang.h"
 
 // config files
 
@@ -20,7 +21,7 @@
 #define DEFAULT_SAVESTATS       false
 #define DEFAULT_INVERTCOLORS    false
 #define DEFAULT_BRIGHTNESS      250
-#define DEFAULT_LANGUAGE        0
+#define DEFAULT_LANGUAGE        LANG_ZH_TW
 
 // JSON config files
 #define JSON_CONFIG_FILE        "/config.json"

--- a/src/lang/lang.cpp
+++ b/src/lang/lang.cpp
@@ -7,10 +7,10 @@ const LanguagePack* CurrentLang = &LanguagePack_en;
 
 void setCurrentLang(uint8_t lang) {
     switch (lang) {
-        case 1:
+        case LANG_ZH_TW:
             CurrentLang = &LanguagePack_zh_tw;
             break;
-        case 2:
+        case LANG_JA:
             CurrentLang = &LanguagePack_ja;
             break;
         default:

--- a/src/lang/lang.h
+++ b/src/lang/lang.h
@@ -43,6 +43,12 @@ struct LanguagePack {
     const char* text[LANG_TEXT_MAX];
 };
 
+enum Language {
+    LANG_EN = 0,
+    LANG_ZH_TW,
+    LANG_JA,
+};
+
 extern const LanguagePack LanguagePack_en;
 extern const LanguagePack LanguagePack_zh_tw;
 extern const LanguagePack LanguagePack_ja;

--- a/src/wManager.cpp
+++ b/src/wManager.cpp
@@ -145,10 +145,10 @@ void init_WifiManager()
     char langSel1[10] = "";
     char langSel2[10] = "";
     switch (Settings.Language) {
-        case 1:
+        case LANG_ZH_TW:
             strcpy(langSel1, "selected");
             break;
-        case 2:
+        case LANG_JA:
             strcpy(langSel2, "selected");
             break;
         default:
@@ -157,8 +157,8 @@ void init_WifiManager()
     }
     char languageDropdown[200];
     snprintf(languageDropdown, sizeof(languageDropdown),
-             "<br/><label for='language'>Language</label><select name='language' id='language'><option value='0' %s>English</option><option value='1' %s>繁中</option><option value='2' %s>日本語</option></select>",
-             langSel0, langSel1, langSel2);
+             "<br/><label for='language'>Language</label><select name='language' id='language'><option value='%d' %s>English</option><option value='%d' %s>繁中</option><option value='%d' %s>日本語</option></select>",
+             LANG_EN, langSel0, LANG_ZH_TW, langSel1, LANG_JA, langSel2);
     WiFiManagerParameter language_dropdown(languageDropdown);
 
     // Text box (String) - 80 characters maximum


### PR DESCRIPTION
## Summary
- 新增 Language 列舉並將 DEFAULT_LANGUAGE 設為 LANG_ZH_TW
- WiFiManager 設定頁預設顯示繁體中文

## Testing
- `pio run -e M5Stick-C`（環境缺少 PlatformIO 無法執行）
- `python3 -m pip install platformio`（安裝失敗：proxy 403）

------
https://chatgpt.com/codex/tasks/task_e_68b11034e9948321bba1529697e45f2b