### PR TITLE
Include Arduino header in language module

### DIFF
--- a/src/lang/lang.h
+++ b/src/lang/lang.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <Arduino.h>
 
 enum LangText {
     LANG_TEXT_STATS,


### PR DESCRIPTION
## Summary
- include `<Arduino.h>` at the top of `lang.h` so `uint8_t` is defined

## Testing
- `platformio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio due to proxy restrictions)*
- `g++ -std=c++17 -c src/lang/lang.cpp -I/tmp -Isrc/lang -o /tmp/lang.o`


------
https://chatgpt.com/codex/tasks/task_e_68b114b7b248832184f731c9c7621998