### PR TITLE
利用 WiFiManager 內建伺服器提供狀態路由

### DIFF
--- a/src/NerdMinerV2.ino.cpp
+++ b/src/NerdMinerV2.ino.cpp
@@ -3,7 +3,6 @@
 
 #include <Arduino.h>
 #include <WiFi.h>
-#include <WebServer.h>
 #include <esp_task_wdt.h>
 #include <OneButton.h>
 
@@ -49,7 +48,6 @@ extern TSettings Settings;
 
 /**********************⚡ GLOBAL Vars *******************************/
 
-WebServer server(80);
 void handleStatus();
 
 unsigned long start = millis();
@@ -123,9 +121,6 @@ void setup()
   init_WifiManager();
   setCurrentLang(Settings.Language);
 
-  server.on("/", handleStatus);
-  server.begin();
-
   /******** CREATE TASK TO PRINT SCREEN *****/
   //tft.pushImage(0, 0, MinerWidth, MinerHeight, MinerScreen);
   // Higher prio monitor task
@@ -181,7 +176,7 @@ void handleStatus() {
   json += "\"completedShares\":\"" + data.completedShares + "\",";
   json += "\"bestDiff\":\"" + data.bestDiff + "\"";
   json += "}";
-  server.send(200, "application/json", json);
+  wm.server->send(200, "application/json", json);
 }
 
 void loop() {
@@ -198,7 +193,6 @@ void loop() {
   touchHandler.isTouched();
 #endif
   wifiManagerProcess(); // avoid delays() in loop when non-blocking and other long running code
-  server.handleClient();
 
   vTaskDelay(50 / portTICK_PERIOD_MS);
 }

--- a/src/wManager.cpp
+++ b/src/wManager.cpp
@@ -17,6 +17,7 @@
 #include "timeconst.h"
 #include "lang/lang.h"
 
+extern void handleStatus();
 
 // Flag for saving data
 bool shouldSaveConfig = false;
@@ -297,6 +298,8 @@ void init_WifiManager()
         Serial.println(LANG_TEXT_WIFI_CONNECTED);
         Serial.print(LANG_TEXT_IP_ADDRESS_COLON);
         Serial.println(WiFi.localIP());
+        wm.server->on("/status", handleStatus);
+        wm.startWebPortal();
 
 
         // Lets deal with the user config values

--- a/src/wManager.h
+++ b/src/wManager.h
@@ -1,6 +1,10 @@
 #ifndef _WMANAGER_H
 #define _WMANAGER_H
 
+#include <WiFiManager.h>
+
+extern WiFiManager wm;
+
 void init_WifiManager();
 void wifiManagerProcess();
 void reset_configuration();


### PR DESCRIPTION
## Summary
- 改用 WiFiManager 內建的 `wm.server`，並在連線後啟動 WebPortal。
- 新增 `/status` 路由提供挖礦狀態資料。
- 以 `wifiManagerProcess()` 取代原本的 `server.handleClient()` 處理 HTTP 請求。

## Testing
- `pio run -e NerdminerV2` *(failed: command not found)*
- `pip install platformio` *(failed: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68b1211ac2808321993a84003de35a16